### PR TITLE
optimize: merged phase `rewrite` and `access`, make it faster.

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -87,10 +87,6 @@ http {
             set $upstream_connection         '';
             set $upstream_uri                '';
 
-            rewrite_by_lua_block {
-                apisix.rewrite_phase()
-            }
-
             access_by_lua_block {
                 apisix.access_phase()
             }

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -80,10 +80,6 @@ http {
             set $upstream_connection         '';
             set $upstream_uri                '';
 
-            rewrite_by_lua_block {
-                apisix.rewrite_phase()
-            }
-
             access_by_lua_block {
                 apisix.access_phase()
             }

--- a/lua/apisix.lua
+++ b/lua/apisix.lua
@@ -68,7 +68,7 @@ local function run_plugin(phase, filter_plugins, api_ctx)
 end
 
 
-function _M.rewrite_phase()
+function _M.access_phase()
     local ngx_ctx = ngx.ctx
     local api_ctx = ngx_ctx.api_ctx
 
@@ -125,10 +125,7 @@ function _M.rewrite_phase()
     api_ctx.filter_plugins = plugin.filter(route)
 
     run_plugin("rewrite", api_ctx.filter_plugins, api_ctx)
-end
-
-function _M.access_phase()
-    run_plugin("access")
+    run_plugin("access", api_ctx.filter_plugins, api_ctx)
 end
 
 function _M.header_filter_phase()

--- a/t/APISix.pm
+++ b/t/APISix.pm
@@ -42,10 +42,6 @@ _EOC_
     if (!$config) {
     $config .= <<_EOC_;
         location / {
-            rewrite_by_lua_block {
-                apisix.rewrite_phase()
-            }
-
             access_by_lua_block {
                 apisix.access_phase()
             }

--- a/t/sanity.t
+++ b/t/sanity.t
@@ -13,7 +13,7 @@ __DATA__
     location /t {
         content_by_lua_block {
             local apisix = require("apisix")
-            apisix.rewrite_phase()
+            apisix.access_phase()
         }
     }
 --- request


### PR DESCRIPTION
Performance improvement 5%.

old version:

```shell
[rain@instance-2 ~]$ wrk -d 30 http://127.0.0.2:9080/hello
Running 30s test @ http://127.0.0.2:9080/hello
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   578.93us  172.11us  10.87ms   85.12%
    Req/Sec     8.52k   639.31     9.99k    74.09%
  510290 requests in 30.10s, 637.49MB read
Requests/sec:  16953.25
Transfer/sec:     21.18MB
[rain@instance-2 ~]$ wrk -d 30 http://127.0.0.2:9080/hello
Running 30s test @ http://127.0.0.2:9080/hello
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   600.37us  196.83us  19.64ms   87.48%
    Req/Sec     8.21k   732.85     9.67k    71.00%
  490182 requests in 30.00s, 612.37MB read
Requests/sec:  16338.44
Transfer/sec:     20.41MB
```

new version:

```
[rain@instance-2 ~]$ wrk -d 30 http://127.0.0.2:9080/hello
Running 30s test @ http://127.0.0.2:9080/hello
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   557.54us  154.85us  10.25ms   84.31%
    Req/Sec     8.84k   526.89    10.56k    73.83%
  527755 requests in 30.01s, 659.31MB read
Requests/sec:  17587.93
Transfer/sec:     21.97MB
[rain@instance-2 ~]$ wrk -d 30 http://127.0.0.2:9080/hello
Running 30s test @ http://127.0.0.2:9080/hello
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   565.17us  181.30us  14.39ms   87.44%
    Req/Sec     8.72k     0.89k   17.18k    72.71%
  521661 requests in 30.10s, 651.69MB read
Requests/sec:  17331.02
Transfer/sec:     21.65MB
```