### PR TITLE
bugfix: failed early when lua isn't installed on `make dev`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ else
 endif
 
 
-### check:        Check Lua srouce code
+### check:        Check Lua source code
 .PHONY: check
 check:
 	luacheck -q lua

--- a/utils/update_nginx_conf_dev.sh
+++ b/utils/update_nginx_conf_dev.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-lua_version=`lua -e "print(_VERSION)" | grep -o -E "(5.[0-9])"`
+lua_version=`lua -e "print(_VERSION)" 2>/dev/null | grep -o -E "(5.[0-9])"`
 
-if [ $lua_version = "5.1" ];then
-    echo "current Lua version is 5.1, skip to update conf/nginx.conf"
+if [ -z "$lua_version" ]; then
+    echo "Lua 5.x environment (luarocks included) should be installed in advance."
+    exit 1
+elif [ $lua_version = "5.1" ];then
+    echo "Current Lua version is 5.1, skip to update conf/nginx.conf."
     exit
 fi
 


### PR DESCRIPTION
When run `make dev` on a new host without lua 5.x environment,  the output isn't very friendly，the `lua_version` variable is empty but `utils/update_nginx_conf_dev.sh` continue execute the sed substitution，which is meaningless.

fix spelling mistake in `Makefile`: `srouce code` -> `source code`