### PR TITLE
Add timeout to init_etcd

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -332,11 +332,17 @@ local function init_etcd(show_output)
     local etcd_conf = yaml_conf.etcd
     local uri = etcd_conf.host .. "/v2/keys" .. (etcd_conf.prefix or "")
 
+    local timeout = etcd_conf.timeout
+    if timeout == nil then
+      timeout = 1
+    end
+
     for _, dir_name in ipairs({"/routes", "/upstreams", "/services",
                                "/plugins", "/consumers", "/node_status",
                                "/ssl"}) do
         local cmd = "curl " .. uri .. dir_name
-                    .. "?prev_exist=false -X PUT -d dir=true 2>&1"
+                    .. "?prev_exist=false -X PUT -d dir=true --connect-timeout " .. timeout .. " --max-time " .. timeout * 2 .. " --retry 1 2>&1"
+
         local res = exec(cmd)
         if not res:find([[index]], 1, true)
            and not res:find([[createdIndex]], 1, true) then


### PR DESCRIPTION
Hi there,

The curl default connect timeout is 120s or more, we should use the timeout in the configuration.

Please review it. thx.

