### PR TITLE
Update nginx.conf

### DIFF
--- a/bin/apisix
+++ b/bin/apisix
@@ -145,7 +145,7 @@ http {
     server {
         listen {* port_admin *};
 
-        location /apisix/admin {
+        location /apisix/admin/ {
             {% for _, allow_ip in ipairs(allow_admin) do %}
             allow {*allow_ip*};
             {% end %}
@@ -191,14 +191,14 @@ http {
             apisix.http_ssl_phase()
         }
 
-        location /apisix/dashboard {
+        location /apisix/dashboard/ {
             index index.html;
             {% for _, allow_ip in ipairs(allow_admin) do %}
             allow {*allow_ip*};
             {% end %}
             deny all;
 
-            root ../;
+            alias dashboard/;
 
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Real-PORT $remote_port;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -90,7 +90,7 @@ http {
             stub_status;
         }
 
-        location /apisix/admin {
+        location /apisix/admin/ {
             allow 127.0.0.0/24;
             deny all;
 
@@ -103,7 +103,7 @@ http {
             apisix.http_ssl_phase()
         }
 
-        location /apisix/dashboard {
+        location /apisix/dashboard/ {
             index index.html;
             allow 127.0.0.0/24;
             deny all;

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -108,7 +108,7 @@ http {
             allow 127.0.0.0/24;
             deny all;
 
-            root ../;
+            alias dashboard/;
 
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Real-PORT $remote_port;


### PR DESCRIPTION
Change `root ../;` to `alias dashboard/;` for location /apisix/dashboard/ prefix.
The directive `root ../;` depends on the fact that parent directory name must be `apisix` and not symbolic link.
When enter the working directory with symbolic link `apisix -> releases/v0.7`, `root ../` would use `releases` directory as root directory, that's not we expected.