### PR TITLE
bugfix: Windows uses `CRLF` by default, but Linux uses `LF` by default

### DIFF
--- a/lua/apisix/core/yaml.lua
+++ b/lua/apisix/core/yaml.lua
@@ -740,7 +740,7 @@ end
 
 local function parse(source)
   local lines = {}
-  for line in string.gmatch(source .. '\n', '(.-)\n') do
+  for line in string.gmatch(source .. '\n', '(.-)\r?\n') do
     tinsert(lines, line)
   end
 


### PR DESCRIPTION
  and needs to be compatible at the same time.