### PR TITLE
bugfix:issue #94, typo in plugin

### DIFF
--- a/lua/apisix/plugins/example-plugin.lua
+++ b/lua/apisix/plugins/example-plugin.lua
@@ -51,7 +51,7 @@ end
 
 
 function _M.balancer(conf, ctx)
-    core.log.warn("plugin access phase, conf: ", core.json.encode(conf))
+    core.log.warn("plugin balancer phase, conf: ", core.json.encode(conf))
 
     if not conf.ip then
         return


### PR DESCRIPTION
change log content as below:
core.log.warn("plugin balancer phase, conf: ", core.json.encode(conf))
