### PR TITLE
change:closing route module get uri parameter variable `api_ctx.matched_params`

### DIFF
--- a/lua/apisix/http/router/r3_host_uri.lua
+++ b/lua/apisix/http/router/r3_host_uri.lua
@@ -50,8 +50,9 @@ local function push_valid_route(route)
             remote_addr = route.value.remote_addr,
             handler = function (params, api_ctx)
                 --[[
-                    If you need to get the parameters, you need to replace the first parameter nil of dispatch2 with
-                    an empty table and open the following comment, but this will affect performance.
+                    If you need to get the parameters, you need to replace the first parameter
+                    nil of dispatch2 with an empty table and open the following comment, but
+                    this will affect performance.
                 --]]
                 -- api_ctx.matched_params = params
                 api_ctx.matched_route = route
@@ -72,8 +73,9 @@ local function push_valid_route(route)
         remote_addr = route.value.remote_addr,
         handler = function (params, api_ctx)
             --[[
-                If you need to get the parameters, you need to replace the first parameter nil of dispatch2 with
-                an empty table and open the following comment, but this will affect performance.
+                If you need to get the parameters, you need to replace the first parameter
+                nil of dispatch2 with an empty table and open the following comment, but
+                this will affect performance.
             --]]
             -- api_ctx.matched_params = params
             api_ctx.matched_route = route

--- a/lua/apisix/http/router/r3_host_uri.lua
+++ b/lua/apisix/http/router/r3_host_uri.lua
@@ -49,7 +49,11 @@ local function push_valid_route(route)
             method = route.value.methods,
             remote_addr = route.value.remote_addr,
             handler = function (params, api_ctx)
-                api_ctx.matched_params = params
+                --[[
+                    If you need to get the parameters, you need to replace the first parameter nil of dispatch2 with
+                    an empty table and open the following comment, but this will affect performance.
+                --]]
+                -- api_ctx.matched_params = params
                 api_ctx.matched_route = route
             end
         })
@@ -67,7 +71,11 @@ local function push_valid_route(route)
         method = route.value.methods,
         remote_addr = route.value.remote_addr,
         handler = function (params, api_ctx)
-            api_ctx.matched_params = params
+            --[[
+                If you need to get the parameters, you need to replace the first parameter nil of dispatch2 with
+                an empty table and open the following comment, but this will affect performance.
+            --]]
+            -- api_ctx.matched_params = params
             api_ctx.matched_route = route
         end
     })

--- a/lua/apisix/http/router/r3_uri.lua
+++ b/lua/apisix/http/router/r3_uri.lua
@@ -39,7 +39,11 @@ local function create_r3_router(routes)
                 method = route.value.methods,
                 host = route.value.host,
                 handler = function (params, api_ctx)
-                    api_ctx.matched_params = params
+                    --[[
+                        If you need to get the parameters, you need to replace the first parameter nil of dispatch2 with
+                        an empty table and open the following comment, but this will affect performance.
+                    --]]
+                    -- api_ctx.matched_params = params
                     api_ctx.matched_route = route
                 end
             })

--- a/lua/apisix/http/router/r3_uri.lua
+++ b/lua/apisix/http/router/r3_uri.lua
@@ -40,8 +40,9 @@ local function create_r3_router(routes)
                 host = route.value.host,
                 handler = function (params, api_ctx)
                     --[[
-                        If you need to get the parameters, you need to replace the first parameter nil of dispatch2 with
-                        an empty table and open the following comment, but this will affect performance.
+                        If you need to get the parameters, you need to replace the first parameter
+                        nil of dispatch2 with an empty table and open the following comment, but
+                        this will affect performance.
                     --]]
                     -- api_ctx.matched_params = params
                     api_ctx.matched_route = route


### PR DESCRIPTION
Applying/recycling tables in lua is time consuming, so use temporary tables as little as possible. Obtaining the uri parameter operation is relatively low frequency, and the user can conveniently intercept the uri parameter from the plugin. It is not necessary to apply a temporary table every time for this low-frequency operation, and the parameter acquisition is currently closed using a comment. It can be turned on manually if needed, but it will affect performance.

在 lua 中申请/回收 table 是比较耗时的，所以要尽量少的使用临时 table。获取uri参数操作比较低频，且用户可以方便的从插件中截取uri参数。不必要为了这个低频的操作每次申请临时table，当前使用注释的方式关闭参数获取。如果有需要的话可以手动开启，但是会影响性能。