### PR TITLE
Each upstream service only needs to create a health check instance, o…

### DIFF
--- a/lua/apisix/balancer.lua
+++ b/lua/apisix/balancer.lua
@@ -73,7 +73,7 @@ end
 
 local function create_checker(upstream, healthcheck_parent)
     local checker = healthcheck.new({
-        name = "upstream#" .. tostring(upstream),
+        name = "upstream#" .. healthcheck_parent.key,
         shm_name = "upstream-healthcheck",
         checks = upstream.checks,
     })


### PR DESCRIPTION
…therwise each work will periodically detect the upstream service. 每个上游服务只需要创建一个健康检查实例，否则每个work都会定时探活上游服务

NOTE: Please read the Contributing.md guidelines before submitting your patch:

https://github.com/iresty/apisix/blob/master/Contributing.md#how-to-add-a-new-feature-or-change-an-existing-one

### Summary

SUMMARY_HERE

### Full changelog

* [Implement ...]
* [Add related tests]
* ...

### Issues resolved

Fix #XXX
