### PR TITLE
feature(plugin): rewrite upstream info with plugin `proxy-rewrite`

### DIFF
--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -52,6 +52,7 @@ plugins:                          # plugin list
   - serverless-pre-function
   - serverless-post-function
   - openid-connect
+  - proxy-rewrite
 
 stream_plugins:
   - mqtt-proxy

--- a/doc/plugins/proxy-rewrite-cn.md
+++ b/doc/plugins/proxy-rewrite-cn.md
@@ -8,7 +8,7 @@
 |-------         |-----|------|
 |scheme          |可选| 转发到上游的新`schema` 协议，可以是`http`或`https`，默认`http`协议|
 |uri             |可选| 转发到上游的新`uri` 地址|
-|host            |可选| 转发到上游的新`host` 地址，格式可以为`192.168.80.128:8080`或`192.168.80.128`如果未设置端口将默认设置为`80`，此配置优先级将高于`upstream.nodes` |
+|host            |可选| 转发到上游的新`host` 地址，例如：`iresty.com` |
 |enable_websocket|可选| 是否启用`websocket`（布尔值），默认不启用|
 
 ### 示例
@@ -25,7 +25,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
         "proxy-rewrite": {
             "uri": "/test/home.html",
             "scheme": "http",
-            "host": "192.168.80.128:8080",
+            "host": "iresty.com",
             "enable_websocket": true
         }
     },
@@ -39,15 +39,14 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
 ```
 
 #### 测试插件
-基于上述配置进行测试，测试前在 Nginx 配置文件 access 日志输出配置中补充 `$upstream_scheme $upstream_addr $upstream_uri` 变量。
+基于上述配置进行测试：
 ```shell
 curl -X GET http://127.0.0.1:9080/test/index.html
 ```
 
-发送请求，查看 `access.log`，如果输出信息与配置一致：
+发送请求，查看上游服务`access.log`，如果输出信息与配置一致：
 ```
-127.0.0.1 - - [25/Sep/2019:19:35:58 +0800] 127.0.0.1:9080 "GET /test/index.html HTTP/1.1" 200 38 0.007 
-"-" "curl/7.29.0" http 192.168.80.128:8080 /test/home.html 200 0.007
+127.0.0.1 - [26/Sep/2019:10:52:20 +0800] iresty.com GET /test/home.html HTTP/1.1 200 38 - curl/7.29.0 - 0.000 199 107
 ```
 
 即表示 proxy rewrite 插件生效了。

--- a/doc/plugins/proxy-rewrite-cn.md
+++ b/doc/plugins/proxy-rewrite-cn.md
@@ -1,0 +1,73 @@
+[English](proxy-rewrite.md)
+# proxy-rewrite
+
+上游代理信息重写插件。
+
+#### 配置参数
+|名字    |可选|说明|
+|-------         |-----|------|
+|scheme          |可选| 转发到上游的新`schema` 协议，可以是`http`或`https`，默认`http`协议|
+|uri             |可选| 转发到上游的新`uri` 地址|
+|host            |可选| 转发到上游的新`host` 地址，格式可以为`192.168.80.128:8080`或`192.168.80.128`如果未设置端口将默认设置为`80`，此配置优先级将高于`upstream.nodes` |
+|enable_websocket|可选| 是否启用`websocket`（布尔值），默认不启用|
+
+### 示例
+
+#### 开启插件
+下面是一个示例，在指定的 route 上开启了 proxy rewrite 插件:
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
+{
+    "methods": ["GET"],
+    "uri": "/test/index.html",
+    "plugins": {
+        "proxy-rewrite": {
+            "uri": "/test/home.html",
+            "scheme": "http",
+            "host": "192.168.80.128:8080",
+            "enable_websocket": true
+        }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:80": 1
+        }
+    }
+}'
+```
+
+#### 测试插件
+基于上述配置进行测试，测试前在 Nginx 配置文件 access 日志输出配置中补充 `$upstream_scheme $upstream_addr $upstream_uri` 变量。
+```shell
+curl -X GET http://127.0.0.1:9080/test/index.html
+```
+
+发送请求，查看 `access.log`，如果输出信息与配置一致：
+```
+127.0.0.1 - - [25/Sep/2019:19:35:58 +0800] 127.0.0.1:9080 "GET /test/index.html HTTP/1.1" 200 38 0.007 
+"-" "curl/7.29.0" http 192.168.80.128:8080 /test/home.html 200 0.007
+```
+
+即表示 proxy rewrite 插件生效了。
+
+#### 禁用插件
+当你想去掉 proxy rewrite 插件的时候，很简单，在插件的配置中把对应的 json 配置删除即可，无须重启服务，即刻生效：
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
+{
+    "methods": ["GET"],
+    "uri": "/test/index.html",
+    "plugins": {},
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:80": 1
+        }
+    }
+}'
+```
+
+现在就已经移除了 proxy rewrite 插件了。其他插件的开启和移除也是同样的方法。

--- a/doc/plugins/proxy-rewrite-cn.md
+++ b/doc/plugins/proxy-rewrite-cn.md
@@ -14,7 +14,7 @@
 ### 示例
 
 #### 开启插件
-下面是一个示例，在指定的 route 上开启了 proxy rewrite 插件:
+下面是一个示例，在指定的 route 上开启了 `proxy rewrite` 插件:
 
 ```shell
 curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
@@ -49,10 +49,10 @@ curl -X GET http://127.0.0.1:9080/test/index.html
 127.0.0.1 - [26/Sep/2019:10:52:20 +0800] iresty.com GET /test/home.html HTTP/1.1 200 38 - curl/7.29.0 - 0.000 199 107
 ```
 
-即表示 proxy rewrite 插件生效了。
+即表示 `proxy rewrite` 插件生效了。
 
 #### 禁用插件
-当你想去掉 proxy rewrite 插件的时候，很简单，在插件的配置中把对应的 json 配置删除即可，无须重启服务，即刻生效：
+当你想去掉 `proxy rewrite` 插件的时候，很简单，在插件的配置中把对应的 json 配置删除即可，无须重启服务，即刻生效：
 
 ```shell
 curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
@@ -69,4 +69,4 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
 }'
 ```
 
-现在就已经移除了 proxy rewrite 插件了。其他插件的开启和移除也是同样的方法。
+现在就已经移除了 `proxy rewrite` 插件了。其他插件的开启和移除也是同样的方法。

--- a/doc/plugins/proxy-rewrite.md
+++ b/doc/plugins/proxy-rewrite.md
@@ -1,0 +1,75 @@
+[中文](proxy-rewrite-cn.md)
+# proxy-rewrite
+
+upstream proxy info rewrite plugin.
+
+### Parameters
+|Name    |Must|Description|
+|-------         |-----|------|
+|scheme          |No| Upstream new `schema` forwarding protocol,options can be `http` or `https`,default `http`.|
+|uri             |No| Upstream new `uri` forwarding address.|
+|host            |No| Upstream new `host` forwarding address, can be `192.168.80.128:8080` or `192.168.80.128` format, not set up port default `80`, priority over `upstream.nodes` configuration. |
+|enable_websocket|No| enable `websocket`(boolean), default disable.|
+
+### Example
+
+#### Enable Plugin
+Here's an example, enable the proxy rewrite plugin on the specified route:
+
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
+{
+    "methods": ["GET"],
+    "uri": "/test/index.html",
+    "plugins": {
+        "proxy-rewrite": {
+            "uri": "/test/home.html",
+            "scheme": "http",
+            "host": "192.168.80.128:8080",
+            "enable_websocket": true
+        }
+    },
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:80": 1
+        }
+    }
+}'
+```
+
+#### Test Plugin
+Testing based on the above examples, add the access log output upstream information variable 
+`$upstream_scheme $upstream_addr $upstream_uri` to the nginx configuration file before testing :
+```shell
+curl -X GET http://127.0.0.1:9080/test/index.html
+```
+
+Send the request and see `access.log', if the output information is consistent with the configuration :
+```
+127.0.0.1 - - [25/Sep/2019:19:35:58 +0800] 127.0.0.1:9080 "GET /test/index.html HTTP/1.1" 200 38 0.007 
+"-" "curl/7.29.0" http 192.168.80.128:8080 /test/home.html 200 0.007
+```
+
+This means that the proxy rewrite plugin is in effect.
+
+#### Disable Plugin
+When you want to disable the proxy rewrite plugin, it is very simple,
+ you can delete the corresponding json configuration in the plugin configuration,
+  no need to restart the service, it will take effect immediately :
+```shell
+curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
+{
+    "methods": ["GET"],
+    "uri": "/test/index.html",
+    "plugins": {},
+    "upstream": {
+        "type": "roundrobin",
+        "nodes": {
+            "127.0.0.1:80": 1
+        }
+    }
+}'
+```
+
+The proxy rewrite plugin has been disabled now. It works for other plugins.

--- a/doc/plugins/proxy-rewrite.md
+++ b/doc/plugins/proxy-rewrite.md
@@ -4,12 +4,12 @@
 upstream proxy info rewrite plugin.
 
 ### Parameters
-|Name    |Must|Description|
+|Name    |Required|Description|
 |-------         |-----|------|
 |scheme          |No| Upstream new `schema` forwarding protocol,options can be `http` or `https`,default `http`.|
 |uri             |No| Upstream new `uri` forwarding address.|
-|host            |No| Upstream new `host` forwarding address, can be `192.168.80.128:8080` or `192.168.80.128` format, not set up port default `80`, priority over `upstream.nodes` configuration. |
-|enable_websocket|No| enable `websocket`(boolean), default disable.|
+|host            |No| Upstream new `host` forwarding address, example `iresty.com`. |
+|enable_websocket|No| enable `websocket`(boolean), default `false`.|
 
 ### Example
 
@@ -25,7 +25,7 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
         "proxy-rewrite": {
             "uri": "/test/home.html",
             "scheme": "http",
-            "host": "192.168.80.128:8080",
+            "host": "iresty.com",
             "enable_websocket": true
         }
     },
@@ -39,16 +39,14 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
 ```
 
 #### Test Plugin
-Testing based on the above examples, add the access log output upstream information variable 
-`$upstream_scheme $upstream_addr $upstream_uri` to the nginx configuration file before testing :
+Testing based on the above examples :
 ```shell
 curl -X GET http://127.0.0.1:9080/test/index.html
 ```
 
-Send the request and see `access.log', if the output information is consistent with the configuration :
+Send the request and see upstream `access.log', if the output information is consistent with the configuration :
 ```
-127.0.0.1 - - [25/Sep/2019:19:35:58 +0800] 127.0.0.1:9080 "GET /test/index.html HTTP/1.1" 200 38 0.007 
-"-" "curl/7.29.0" http 192.168.80.128:8080 /test/home.html 200 0.007
+127.0.0.1 - [26/Sep/2019:10:52:20 +0800] iresty.com GET /test/home.html HTTP/1.1 200 38 - curl/7.29.0 - 0.000 199 107
 ```
 
 This means that the proxy rewrite plugin is in effect.

--- a/doc/plugins/proxy-rewrite.md
+++ b/doc/plugins/proxy-rewrite.md
@@ -14,7 +14,7 @@ upstream proxy info rewrite plugin.
 ### Example
 
 #### Enable Plugin
-Here's an example, enable the proxy rewrite plugin on the specified route:
+Here's an example, enable the `proxy rewrite` plugin on the specified route:
 
 ```shell
 curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
@@ -49,10 +49,10 @@ Send the request and see upstream `access.log', if the output information is con
 127.0.0.1 - [26/Sep/2019:10:52:20 +0800] iresty.com GET /test/home.html HTTP/1.1 200 38 - curl/7.29.0 - 0.000 199 107
 ```
 
-This means that the proxy rewrite plugin is in effect.
+This means that the `proxy rewrite` plugin is in effect.
 
 #### Disable Plugin
-When you want to disable the proxy rewrite plugin, it is very simple,
+When you want to disable the `proxy rewrite` plugin, it is very simple,
  you can delete the corresponding json configuration in the plugin configuration,
   no need to restart the service, it will take effect immediately :
 ```shell
@@ -70,4 +70,4 @@ curl http://127.0.0.1:9080/apisix/admin/routes/1 -X PUT -d '
 }'
 ```
 
-The proxy rewrite plugin has been disabled now. It works for other plugins.
+The `proxy rewrite` plugin has been disabled now. It works for other plugins.

--- a/lua/apisix/plugins/proxy-rewrite.lua
+++ b/lua/apisix/plugins/proxy-rewrite.lua
@@ -2,7 +2,6 @@ local core        = require("apisix.core")
 local plugin_name = "proxy-rewrite"
 local pairs       = pairs
 local ipairs      = ipairs
-local ngx         = ngx
 
 local schema = {
     type = "object",
@@ -53,24 +52,15 @@ do
     end
 
 function _M.rewrite(conf, ctx)
-    local ngx_var = ngx.var
-
     for _, name in ipairs(upstream_names) do
         if conf[name] then
-            ngx_var[upstream_vars[name]] = conf[name]
+            ctx.var[upstream_vars[name]] = conf[name]
         end
     end
 
     if conf.enable_websocket then
         ctx.var["upstream_upgrade"]    = ctx.var["http_upgrade"]
         ctx.var["upstream_connection"] = ctx.var["http_connection"]
-    end
-
-    -- rewrite nodes for upstream config ,priority is higher than upstream nodes.
-    if conf.host then
-        local tmp_nodes = {}
-        tmp_nodes[conf.host] = 100
-        ctx.matched_route.value.upstream.nodes = tmp_nodes
     end
 end
 

--- a/lua/apisix/plugins/proxy-rewrite.lua
+++ b/lua/apisix/plugins/proxy-rewrite.lua
@@ -1,0 +1,65 @@
+local core = require("apisix.core")
+local plugin_name = "proxy-rewrite"
+local ipairs = ipairs
+local str_gsub = string.gsub
+
+local schema = {
+    type = "object",
+    properties = {
+
+    },
+}
+
+local _M = {
+    version = 0.1,
+    priority = 1008,
+    name = plugin_name,
+    schema = schema,
+}
+
+local upstream_vars = {
+    uri        = "upstream_uri",
+    scheme     = "upstream_scheme",
+    host       = "upstream_host",
+    upgrade    = "upstream_upgrade",
+    connection = "upstream_connection",
+}
+
+function _M.check_schema(conf)
+    local ok, err = core.schema.check(schema, conf)
+    if not ok then
+        return false, err
+    end
+
+    return true
+end
+
+function _M.rewrite(conf, ctx)
+    local ngx_var = ngx.var
+    local ngx_ctx = ngx.ctx
+    local api_ctx = ngx_ctx.api_ctx
+    core.log.info("------------access-proxy-rewrite-ctx: ", core.json.delay_encode(ctx, true))
+    core.log.info("------------access-proxy-rewrite-conf: ", core.json.delay_encode(conf, true))
+    local new_uri = str_gsub(conf.uri, '{id}', 1001)
+    core.log.info("------------access-proxy-rewrite-new-uri: ", new_uri)
+    core.log.info("------------access-proxy-rewrite-enable: ", conf.enable_websocket)
+    core.log.info("------------conf-length: ", table.maxn(conf))
+    ngx.req.set_uri(new_uri)
+
+    for _, name in ipairs(conf) do
+        if conf[name] then
+            ngx_var[upstream_vars[name]] = conf[name]
+        end
+    end
+
+    if conf.enable_websocket then
+        api_ctx.var["upstream_upgrade"] = api_ctx.var["http_upgrade"]
+        api_ctx.var["upstream_connection"] = api_ctx.var["http_connection"]
+    end
+end
+
+function _M.access(conf, ctx)
+    --
+end
+
+return _M

--- a/lua/apisix/plugins/proxy-rewrite.lua
+++ b/lua/apisix/plugins/proxy-rewrite.lua
@@ -7,20 +7,28 @@ local schema = {
     type = "object",
     properties = {
         uri = {
-            type = "string"
+            description = "new uri for upstream",
+            type        = "string",
+            minLength   = 1,
+            maxLength   = 4096
         },
         host = {
-            type = "string"
+            description = "new host for upstream",
+            type        = "string",
+            pattern     = "^\\*?[0-9a-zA-Z-.]+$",
         },
         scheme = {
+            description = "new scheme for upstream",
             type    = "string",
             enum    = {"http", "https"}
         },
         enable_websocket = {
-            type = "boolean",
-            default = false
+            description = "enable websocket for request",
+            type        = "boolean",
+            default     = false
         }
     },
+    minProperties = 1,
 }
 
 local _M = {

--- a/lua/apisix/plugins/proxy-rewrite.lua
+++ b/lua/apisix/plugins/proxy-rewrite.lua
@@ -2,6 +2,7 @@ local core        = require("apisix.core")
 local plugin_name = "proxy-rewrite"
 local pairs       = pairs
 local ipairs      = ipairs
+local ngx         = ngx
 
 local schema = {
     type = "object",

--- a/lua/apisix/plugins/proxy-rewrite.lua
+++ b/lua/apisix/plugins/proxy-rewrite.lua
@@ -1,28 +1,33 @@
-local core = require("apisix.core")
+local core        = require("apisix.core")
 local plugin_name = "proxy-rewrite"
-local ipairs = ipairs
-local str_gsub = string.gsub
+local pairs       = pairs
+local ipairs      = ipairs
 
 local schema = {
     type = "object",
     properties = {
-
+        uri = {
+            type = "string"
+        },
+        host = {
+            type = "string"
+        },
+        scheme = {
+            type    = "string",
+            enum    = {"http", "https"}
+        },
+        enable_websocket = {
+            type = "boolean",
+            default = false
+        }
     },
 }
 
 local _M = {
-    version = 0.1,
+    version  = 0.1,
     priority = 1008,
-    name = plugin_name,
-    schema = schema,
-}
-
-local upstream_vars = {
-    uri        = "upstream_uri",
-    scheme     = "upstream_scheme",
-    host       = "upstream_host",
-    upgrade    = "upstream_upgrade",
-    connection = "upstream_connection",
+    name     = plugin_name,
+    schema   = schema,
 }
 
 function _M.check_schema(conf)
@@ -30,36 +35,44 @@ function _M.check_schema(conf)
     if not ok then
         return false, err
     end
-
     return true
 end
 
+do
+    local upstream_vars = {
+        uri        = "upstream_uri",
+        scheme     = "upstream_scheme",
+        host       = "upstream_host",
+        upgrade    = "upstream_upgrade",
+        connection = "upstream_connection",
+    }
+    local upstream_names = {}
+    for name, _ in pairs(upstream_vars) do
+        core.table.insert(upstream_names, name)
+    end
+
 function _M.rewrite(conf, ctx)
     local ngx_var = ngx.var
-    local ngx_ctx = ngx.ctx
-    local api_ctx = ngx_ctx.api_ctx
-    core.log.info("------------access-proxy-rewrite-ctx: ", core.json.delay_encode(ctx, true))
-    core.log.info("------------access-proxy-rewrite-conf: ", core.json.delay_encode(conf, true))
-    local new_uri = str_gsub(conf.uri, '{id}', 1001)
-    core.log.info("------------access-proxy-rewrite-new-uri: ", new_uri)
-    core.log.info("------------access-proxy-rewrite-enable: ", conf.enable_websocket)
-    core.log.info("------------conf-length: ", table.maxn(conf))
-    ngx.req.set_uri(new_uri)
 
-    for _, name in ipairs(conf) do
+    for _, name in ipairs(upstream_names) do
         if conf[name] then
             ngx_var[upstream_vars[name]] = conf[name]
         end
     end
 
     if conf.enable_websocket then
-        api_ctx.var["upstream_upgrade"] = api_ctx.var["http_upgrade"]
-        api_ctx.var["upstream_connection"] = api_ctx.var["http_connection"]
+        ctx.var["upstream_upgrade"]    = ctx.var["http_upgrade"]
+        ctx.var["upstream_connection"] = ctx.var["http_connection"]
+    end
+
+    -- rewrite nodes for upstream config ,priority is higher than upstream nodes.
+    if conf.host then
+        local tmp_nodes = {}
+        tmp_nodes[conf.host] = 100
+        ctx.matched_route.value.upstream.nodes = tmp_nodes
     end
 end
 
-function _M.access(conf, ctx)
-    --
-end
+end  -- do
 
 return _M

--- a/t/APISIX.pm
+++ b/t/APISIX.pm
@@ -154,6 +154,7 @@ _EOC_
         listen 1980;
         listen 1981;
         listen 1982;
+        server_name apisix.iresty.com;
 
         server_tokens off;
 

--- a/t/admin/plugins.t
+++ b/t/admin/plugins.t
@@ -14,6 +14,6 @@ __DATA__
 --- request
 GET /apisix/admin/plugins/list
 --- response_body_like eval
-qr/\["limit-req","limit-count","limit-conn","key-auth","prometheus","node-status","jwt-auth","zipkin","ip-restriction","grpc-transcode","serverless-pre-function","serverless-post-function","openid-connect"\]/
+qr/\["limit-req","limit-count","limit-conn","key-auth","prometheus","node-status","jwt-auth","zipkin","ip-restriction","grpc-transcode","serverless-pre-function","serverless-post-function","openid-connect","proxy-rewrite"\]/
 --- no_error_log
 [error]

--- a/t/debug-mode.t
+++ b/t/debug-mode.t
@@ -44,6 +44,7 @@ loaded plugin and sort by priority: 3000 name: ip-restriction
 loaded plugin and sort by priority: 2599 name: openid-connect
 loaded plugin and sort by priority: 2510 name: jwt-auth
 loaded plugin and sort by priority: 2500 name: key-auth
+loaded plugin and sort by priority: 1008 name: proxy-rewrite
 loaded plugin and sort by priority: 1003 name: limit-conn
 loaded plugin and sort by priority: 1002 name: limit-count
 loaded plugin and sort by priority: 1001 name: limit-req

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -1,4 +1,5 @@
 local json_decode = require("cjson").decode
+local json_encode = require("cjson").encode
 
 local _M = {}
 
@@ -22,6 +23,13 @@ function _M.limit_conn()
     ngx.say("hello world")
 end
 
+function _M.plugin_proxy_rewrite()
+    local req_info = {}
+    req_info['uri'] = ngx.var.uri
+    req_info['host'] = ngx.var.host
+    req_info['scheme'] = ngx.var.scheme
+    ngx.say(json_encode(req_info))
+end
 
 function _M.status()
     ngx.say("ok")

--- a/t/lib/server.lua
+++ b/t/lib/server.lua
@@ -24,11 +24,9 @@ function _M.limit_conn()
 end
 
 function _M.plugin_proxy_rewrite()
-    local req_info = {}
-    req_info['uri'] = ngx.var.uri
-    req_info['host'] = ngx.var.host
-    req_info['scheme'] = ngx.var.scheme
-    ngx.say(json_encode(req_info))
+    ngx.say("uri: ", ngx.var.uri)
+    ngx.say("host: ", ngx.var.host)
+    ngx.say("scheme: ", ngx.var.scheme)
 end
 
 function _M.status()

--- a/t/plugin/proxy-rewrite.t
+++ b/t/plugin/proxy-rewrite.t
@@ -1,0 +1,235 @@
+BEGIN {
+    if ($ENV{TEST_NGINX_CHECK_LEAK}) {
+        $SkipReason = "unavailable for the hup tests";
+
+    } else {
+        $ENV{TEST_NGINX_USE_HUP} = 1;
+        undef $ENV{TEST_NGINX_USE_STAP};
+    }
+}
+
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_shuffle();
+no_root_location();
+run_tests;
+
+__DATA__
+
+=== TEST 1: sanity
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.proxy-rewrite")
+            local ok, err = plugin.check_schema({
+                uri = '/apisix/home',
+                host = 'apisix.iresty.com',
+                enable_websocket = true,
+                scheme = 'http'
+            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+done
+--- no_error_log
+[error]
+
+
+=== TEST 2: wrong value of key
+--- config
+    location /t {
+        content_by_lua_block {
+            local plugin = require("apisix.plugins.proxy-rewrite")
+            local ok, err = plugin.check_schema({
+                uri = '/apisix/home',
+                host = 'apisix.iresty.com',
+                enable_websocket = true,
+                scheme = 'tcp'
+            })
+            if not ok then
+                ngx.say(err)
+            end
+
+            ngx.say("done")
+        }
+    }
+--- request
+GET /t
+--- response_body
+invalid "enum" in docuement at pointer "#/scheme"
+done
+--- no_error_log
+[error]
+
+
+=== TEST 3: add plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "proxy-rewrite": {
+                            "uri": "/test/add",
+                            "scheme": "https",
+                            "host": "apisix.iresty.com",
+                            "enable_websocket": true
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+=== TEST 4: update plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                        "proxy-rewrite": {
+                            "uri": "/test/update",
+                            "scheme": "http",
+                            "host": "apisix.iresty.com",
+                            "enable_websocket": false
+                        }
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+=== TEST 5: disable plugin
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                    "plugins": {
+                    },
+                    "upstream": {
+                        "nodes": {
+                            "127.0.0.1:1980": 1
+                        },
+                        "type": "roundrobin"
+                    },
+                    "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+=== TEST 6: set route(id: 1)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/routes/1',
+                 ngx.HTTP_PUT,
+                 [[{
+                        "methods": ["GET"],
+                        "plugins": {
+                            "proxy-rewrite": {
+                                "uri": "/plugin_proxy_rewrite",
+                                "scheme": "http",
+                                "host": "apisix.iresty.com",
+                                "enable_websocket": false
+                            }
+                        },
+                        "upstream": {
+                            "nodes": {
+                                "127.0.0.1:1980": 1
+                            },
+                            "type": "roundrobin"
+                        },
+                        "uri": "/hello"
+                }]]
+                )
+
+            if code >= 300 then
+                ngx.status = code
+            end
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+=== TEST 7: rewrite
+--- request
+GET /hello
+--- response_body
+{"host":"apisix.iresty.com","scheme":"http","uri":"\/plugin_proxy_rewrite"}
+--- no_error_log
+[error]

--- a/t/plugin/proxy-rewrite.t
+++ b/t/plugin/proxy-rewrite.t
@@ -199,7 +199,7 @@ passed
                                 "uri": "/plugin_proxy_rewrite",
                                 "scheme": "http",
                                 "host": "apisix.iresty.com",
-                                "enable_websocket": false
+                                "enable_websocket": true
                             }
                         },
                         "upstream": {
@@ -228,8 +228,10 @@ passed
 
 === TEST 7: rewrite
 --- request
-GET /hello
+GET /hello HTTP/1.1
 --- response_body
-{"host":"apisix.iresty.com","scheme":"http","uri":"\/plugin_proxy_rewrite"}
+uri: /plugin_proxy_rewrite
+host: apisix.iresty.com
+scheme: http
 --- no_error_log
 [error]


### PR DESCRIPTION
This plugin is used to separate `uri`, `host`, `scheme` and `enable_websocket` work in the `upstream` module. Through this plugin, the simplicity and independence of the `upstream` module can be maintained.
此插件用于分离`upstream`模块中的`uri`、`host`、`scheme`和`enable_websocket`功能。让`upstream`模块可以保持简洁和独立性。

### Issues resolved

Fix #569
