### PR TITLE
bugfix: support more Nginx-built-in paramters when set chash balancer

### DIFF
--- a/lua/apisix/schema_def.lua
+++ b/lua/apisix/schema_def.lua
@@ -236,7 +236,7 @@ local upstream_schema = {
         key = {
             description = "the key of chash for dynamic load balancing",
             type = "string",
-            enum = {"remote_addr"},
+            pattern = [[^((uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname)|arg_[0-9a-zA-z_-]+)$]],
         },
         desc = {type = "string", maxLength = 256},
         id = id_schema

--- a/sftp-config.json
+++ b/sftp-config.json
@@ -1,0 +1,45 @@
+{
+    // The tab key will cycle through the settings when first created
+    // Visit http://wbond.net/sublime_packages/sftp/settings for help
+    
+    // sftp, ftp or ftps
+    "type": "sftp",
+
+    "save_before_upload": true,
+    "upload_on_save": true,
+    "sync_down_on_open": false,
+    "sync_skip_deletes": false,
+    "sync_same_age": true,
+    "confirm_downloads": false,
+    "confirm_sync": true,
+    "confirm_overwrite_newer": false,
+    
+    "host": "qtest.hellotalk.org",
+    "user": "root",
+    "password": "HT@monca#Test652",
+    //"port": "22",
+    
+    "remote_path": "/home/git/apisix",
+    "ignore_regexes": [
+        "\\.sublime-(project|workspace)", "sftp-config(-alt\\d?)?\\.json",
+        "sftp-settings\\.json", "/venv/", "\\.svn/", "\\.hg/", "\\.git/",
+        "\\.bzr", "_darcs", "CVS", "\\.DS_Store", "Thumbs\\.db", "desktop\\.ini"
+    ],
+    //"file_permissions": "664",
+    //"dir_permissions": "775",
+    
+    //"extra_list_connections": 0,
+
+    "connect_timeout": 30,
+    //"keepalive": 120,
+    //"ftp_passive_mode": true,
+    //"ftp_obey_passive_host": false,
+    //"ssh_key_file": "~/.ssh/id_rsa",
+    //"sftp_flags": ["-F", "/path/to/ssh_config"],
+    
+    //"preserve_modification_times": false,
+    //"remote_time_offset_in_hours": 0,
+    //"remote_encoding": "utf-8",
+    //"remote_locale": "C",
+    //"allow_config_upload": false,
+}

--- a/t/admin/upstream.t
+++ b/t/admin/upstream.t
@@ -782,3 +782,75 @@ GET /t
 passed
 --- no_error_log
 [error]
+
+
+
+=== TEST 24: set chash upstream(id: 1)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/upstreams/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "nodes": {
+                        "127.0.0.1:8080": 1,
+                        "127.0.0.1:8081": 2
+                    },
+                    "type": "chash",
+                    "key":"arg_device_id"
+                    "desc": "new upstream"
+                }]],
+                [[{
+                    "nodes": {
+                        "127.0.0.1:8080": 3,
+                        "127.0.0.1:8081": 4
+                    },
+                    "type": "chash",
+                    "key":"uri"
+                    "desc": "new upstream"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- response_body
+passed
+--- no_error_log
+[error]
+
+
+
+=== TEST 25: set chash upstream(id: 1)
+--- config
+    location /t {
+        content_by_lua_block {
+            local t = require("lib.test_admin").test
+            local code, body = t('/apisix/admin/upstreams/1',
+                ngx.HTTP_PUT,
+                [[{
+                    "nodes": {
+                        "127.0.0.1:8080": 3,
+                        "127.0.0.1:8081": 4
+                    },
+                    "type": "chash",
+                    "key":"bad_param"
+                    "desc": "new upstream"
+                }]]
+                )
+
+            ngx.status = code
+            ngx.say(body)
+        }
+    }
+--- request
+GET /t
+--- error_code: 400
+--- response_body
+{"error_msg":"invalid configuration: invalid \"pattern\" in docuement at pointer \"#\/key\""}
+--- no_error_log
+[error]


### PR DESCRIPTION
bugfix: support more Nginx-built-in Paramters when set balancer type …

fix: #717

 

### Summary

 support more `uri|server_name|server_addr|request_uri|remote_port|remote_addr|query_string|host|hostname)|arg_[0-9a-zA-z_-]+`

### Full changelog

* lua\apisix\schema_def.lua

### Issues resolved

Fix #717 
